### PR TITLE
fix: wrap array responses in object for MCP structuredContent compliance

### DIFF
--- a/crates/opencontext-node/index.d.ts
+++ b/crates/opencontext-node/index.d.ts
@@ -78,6 +78,7 @@ export interface SearchOptions {
   limit?: number
   mode?: string
   aggregateBy?: string
+  docType?: string
 }
 /** Load search config */
 export declare function loadSearchConfig(): any

--- a/package-lock.json
+++ b/package-lock.json
@@ -115,6 +115,15 @@
         "@aicontextlab/core-native-win32-x64-msvc": "0.1.0"
       }
     },
+    "node_modules/@aicontextlab/core-native/node_modules/@aicontextlab/core-native-darwin-arm64": {
+      "optional": true
+    },
+    "node_modules/@aicontextlab/core-native/node_modules/@aicontextlab/core-native-darwin-x64": {
+      "optional": true
+    },
+    "node_modules/@aicontextlab/core-native/node_modules/@aicontextlab/core-native-win32-x64-msvc": {
+      "optional": true
+    },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
@@ -14787,17 +14796,6 @@
         "zod": {
           "optional": true
         }
-      }
-    },
-    "node_modules/vectra/node_modules/zod": {
-      "version": "3.25.76",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.25.76.tgz",
-      "integrity": "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
       }
     },
     "node_modules/vfile": {

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -13,6 +13,8 @@ const server = new McpServer({
 });
 
 function toToolResponse(data) {
+  // Wrap arrays in object to comply with MCP structuredContent requirement (must be record, not array)
+  const structured = Array.isArray(data) ? { items: data } : data;
   return {
     content: [
       {
@@ -20,7 +22,7 @@ function toToolResponse(data) {
         text: JSON.stringify(data, null, 2)
       }
     ],
-    structuredContent: data
+    structuredContent: structured
   };
 }
 


### PR DESCRIPTION
MCP protocol requires structuredContent to be a record (object), not an array. Arrays are now wrapped as { items: data } to comply with the specification.

Also adds docType parameter to SearchOptions interface.