### PR TITLE
fix: wrap array responses in object for MCP structuredContent compliance

### DIFF
--- a/crates/opencontext-node/index.d.ts
+++ b/crates/opencontext-node/index.d.ts
@@ -78,6 +78,7 @@ export interface SearchOptions {
   limit?: number
   mode?: string
   aggregateBy?: string
+  docType?: string
 }
 /** Load search config */
 export declare function loadSearchConfig(): any

--- a/src/mcp/server.js
+++ b/src/mcp/server.js
@@ -13,6 +13,8 @@ const server = new McpServer({
 });
 
 function toToolResponse(data) {
+  // Wrap arrays in object to comply with MCP structuredContent requirement (must be record, not array)
+  const structured = Array.isArray(data) ? { items: data } : data;
   return {
     content: [
       {
@@ -20,7 +22,7 @@ function toToolResponse(data) {
         text: JSON.stringify(data, null, 2)
       }
     ],
-    structuredContent: data
+    structuredContent: structured
   };
 }
 


### PR DESCRIPTION
MCP protocol requires structuredContent to be a record (object), not an array. Arrays are now wrapped as { items: data } to comply with the specification.

Also adds docType parameter to SearchOptions interface.