### PR TITLE
feat: extend desktop build workflow to support Linux

### DIFF
--- a/.github/workflows/desktop-build.yml
+++ b/.github/workflows/desktop-build.yml
@@ -59,6 +59,9 @@ jobs:
           - platform: windows-latest
             target: x86_64-pc-windows-msvc
             artifact_name: windows
+          - platform: ubuntu-22.04
+            target: x86_64-unknown-linux-gnu
+            artifact_name: linux
 
     runs-on: ${{ matrix.platform }}
 
@@ -88,6 +91,18 @@ jobs:
       - name: Install Protobuf (Windows)
         if: matrix.platform == 'windows-latest'
         run: choco install protoc -y
+
+      - name: Install Linux dependencies
+        if: matrix.platform == 'ubuntu-22.04'
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y \
+            libwebkit2gtk-4.1-dev \
+            libgtk-3-dev \
+            libayatana-appindicator3-dev \
+            librsvg2-dev \
+            patchelf \
+            protobuf-compiler
 
       - name: Install npm dependencies
         run: npm ci
@@ -183,6 +198,10 @@ jobs:
         if: matrix.platform == 'windows-latest'
         run: npm run tauri build
 
+      - name: Build Tauri app (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        run: npm run tauri build -- --bundles appimage
+
       - name: Upload to Release (macOS)
         if: matrix.platform == 'macos-latest'
         uses: softprops/action-gh-release@v1
@@ -205,6 +224,15 @@ jobs:
           files: |
             src-tauri/target/release/bundle/msi/*.msi
             src-tauri/target/release/bundle/nsis/*.exe
+
+      - name: Upload to Release (Linux)
+        if: matrix.platform == 'ubuntu-22.04'
+        uses: softprops/action-gh-release@v1
+        with:
+          tag_name: desktop-v${{ needs.create-release.outputs.version }}
+          draft: true
+          files: |
+            src-tauri/target/release/bundle/appimage/*.AppImage
 
   publish-release:
     needs: [create-release, build]


### PR DESCRIPTION
- Added support for building on Ubuntu 22.04 with x86_64 architecture.
- Included installation of necessary Linux dependencies for the build process.
- Implemented steps to build the Tauri app and upload the release artifacts for Linux.