### PR TITLE
fix(indexer): skip missing files during build_all indexing

### DIFF
--- a/crates/opencontext-core/src/search/indexer.rs
+++ b/crates/opencontext-core/src/search/indexer.rs
@@ -226,6 +226,16 @@ impl Indexer {
             });
 
             for doc in batch {
+                // Skip files that no longer exist on disk (orphaned DB records)
+                if !std::path::Path::new(&doc.abs_path).exists() {
+                    log::warn!(
+                        "Skipping missing file during indexing: {} (orphaned DB record?)",
+                        doc.rel_path
+                    );
+                    processed_docs += 1;
+                    continue;
+                }
+
                 let content = std::fs::read_to_string(&doc.abs_path)?;
                 if content.trim().is_empty() {
                     processed_docs += 1;


### PR DESCRIPTION
When files are deleted from disk but their records remain in the database (orphaned records), the indexer would fail with "No such file or directory" error. Now it logs a warning and continues indexing the remaining files.