### PR TITLE
feat: add CLI smoke test workflow and improve error handling in nativ…

### DIFF
--- a/.github/workflows/cli-smoke.yml
+++ b/.github/workflows/cli-smoke.yml
@@ -1,0 +1,28 @@
+name: CLI smoke test (no publish)
+
+on:
+  workflow_dispatch:
+
+jobs:
+  linux-cli-smoke:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Install dependencies
+        run: npm install
+
+      - name: Install CLI from repo (no publish)
+        run: npm install -g .
+
+      - name: CLI help
+        run: oc --help
+
+      - name: CLI init (expected to pass; if it fails, we capture logs)
+        run: oc init

--- a/src/core/native.js
+++ b/src/core/native.js
@@ -13,6 +13,8 @@ const path = require('path');
 
 let native = null;
 let nativeError = null;
+let npmError = null;
+let localError = null;
 let initialized = false;
 let loadedFrom = null;
 
@@ -29,6 +31,7 @@ function loadNative() {
     loadedFrom = 'npm';
     return;
   } catch (e) {
+    npmError = e;
     // Not installed via npm, try local
   }
   
@@ -38,6 +41,7 @@ function loadNative() {
     native = require(nativePath);
     loadedFrom = 'local';
   } catch (e) {
+    localError = e;
     nativeError = e;
   }
 }
@@ -72,7 +76,9 @@ function get() {
       `OpenContext native bindings not available.\n` +
       `  If installed via npm: try reinstalling the package\n` +
       `  If developing locally: cd crates/opencontext-node && npm run build\n` +
-      `Error: ${nativeError?.message || 'unknown'}`
+      `  If optional deps were skipped: npm install -g @aicontextlab/cli --include=optional\n` +
+      `Error (npm): ${npmError?.message || 'unknown'}\n` +
+      `Error (local): ${localError?.message || 'unknown'}`
     );
   }
   return native;
@@ -88,7 +94,9 @@ function require_() {
       `OpenContext native bindings not available.\n` +
       `  If installed via npm: try reinstalling the package\n` +
       `  If developing locally: cd crates/opencontext-node && npm run build\n` +
-      `Error: ${nativeError?.message || 'unknown'}`
+      `  If optional deps were skipped: npm install -g @aicontextlab/cli --include=optional\n` +
+      `Error (npm): ${npmError?.message || 'unknown'}\n` +
+      `Error (local): ${localError?.message || 'unknown'}`
     );
   }
 }


### PR DESCRIPTION
…e bindings

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **CI:** Adds `.github/workflows/cli-smoke.yml` to perform a no-publish smoke test on Ubuntu: installs deps, installs the CLI globally from the repo, and verifies `oc --help` and `oc init`.
> 
> **Core (native loader):** Enhances `src/core/native.js` error reporting by tracking separate `npmError` and `localError`, preserving `loadedFrom`, and expanding failure messages with guidance for optional deps (`--include=optional`). Loading order (npm → local) remains unchanged.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit f20905b0e6321b31541020819c8988c85f8b35ad. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->